### PR TITLE
Refactor.

### DIFF
--- a/src/test/java/tests/RegistrationFormTests.java
+++ b/src/test/java/tests/RegistrationFormTests.java
@@ -15,7 +15,6 @@ public class RegistrationFormTests {
     RegistrationPage registrationPage = new RegistrationPage();
     Faker faker = new Faker();
     RandomUtils randomUtils = new RandomUtils();
-    DateAndTimeUtils dateAndTimeUtils = new DateAndTimeUtils();
 
     int phoneNumberLength = 10;
     String firstName = faker.name().firstName();
@@ -71,8 +70,7 @@ public class RegistrationFormTests {
         registrationPage.checkRegistrationResultData("Student Email", email);
         registrationPage.checkRegistrationResultData("Gender", gender);
         registrationPage.checkRegistrationResultData("Mobile", phone);
-        registrationPage.checkRegistrationResultData("Date of Birth",
-                dayOfMonth + " " + dateAndTimeUtils.getMonthNameByNumber((Integer.valueOf(month))) + "," +year);
+        registrationPage.checkRegistrationResultData("Date of Birth", dayOfMonth + " " + DateAndTimeUtils.getMonthNameByNumber(Integer.parseInt(month)) + "," +year);
         registrationPage.checkRegistrationResultData("Subjects", subjectFirst + ", " + subjectSecond + ", " +subjectThird);
         registrationPage.checkRegistrationResultData("Hobbies", hobby);
         registrationPage.checkRegistrationResultData("Picture", fileName);


### PR DESCRIPTION
1. No need to create an instance of Utility Class DateAndTimeUtils.
2. You can call getMonthNameByNumber() directly from class reference instead of from an instance, since the method is marked as static.
3. Integer.parseInt is better than Integer.valueOf in this case, because it returns a primitive int instead of an Integer instance.